### PR TITLE
feat: 프로젝트 이미지 업로드 시 webp 포맷 변환 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
 	// mapstruct
     implementation 'org.mapstruct:mapstruct:1.6.2'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.2'
+    
+    // Image Processing
+    implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
+    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/portfolio/service/GcsService.java
+++ b/src/main/java/com/example/portfolio/service/GcsService.java
@@ -18,11 +18,13 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.webp.WebpWriter;
 
 //구글 클라우드 스토리지 관련 로직
 @Service
 public class GcsService {
-	
+
 	@Value("${spring.cloud.gcp.storage.project-id}")
 	private String projectId;
 
@@ -31,33 +33,33 @@ public class GcsService {
 
 	@Value("${spring.cloud.gcp.storage.bucket}")
 	private String bucketName;
-	
+
 	// GCS 업로드 메소드
-	public String uploadFile(MultipartFile multipartFile, Long projectId) throws IOException {
-		// Google Cloud 인증에 사용되는 서비스 계정 키 파일을 스트림 형태로 읽어야 동작
-		// fromStream() 메소드가 InputStream을 매개변수로 받기 때문에 키 파일을 스트림 형태로 읽어와야함		
-		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-		String uuid = UUID.randomUUID().toString();
-		String extension = multipartFile.getContentType();
-		String objectName = projectId + "/" + uuid + "." + extension.split("/")[1];
+//	public String uploadFile(MultipartFile multipartFile, Long projectId) throws IOException {
+//		// Google Cloud 인증에 사용되는 서비스 계정 키 파일을 스트림 형태로 읽어야 동작
+//		// fromStream() 메소드가 InputStream을 매개변수로 받기 때문에 키 파일을 스트림 형태로 읽어와야함
+//		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
+//		String uuid = UUID.randomUUID().toString();
+//		String extension = multipartFile.getContentType();
+//		String objectName = projectId + "/" + uuid + "." + extension.split("/")[1];
+//
+//		Storage storage = StorageOptions.newBuilder().setCredentials(GoogleCredentials.fromStream(keyFile)).build()
+//				.getService();
+//
+//		BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName).setContentType(extension).build();
+//
+//		storage.createFrom(blobInfo, multipartFile.getInputStream());
+//		return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
+//	}
 
-		Storage storage = StorageOptions.newBuilder().setCredentials(GoogleCredentials.fromStream(keyFile)).build()
-				.getService();
-
-		BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName).setContentType(extension).build();
-
-		storage.createFrom(blobInfo, multipartFile.getInputStream());
-		return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
-	}
-
-	// 썸네일 파일 삭제 
+	// 썸네일 파일 삭제
 	public void deleteThumbnailFile(String thumbnailUrl) throws IOException {
 		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
 		Storage storage = StorageOptions.newBuilder().setCredentials(GoogleCredentials.fromStream(keyFile)).build()
 				.getService();
-		
+
 		String objectName = getObjectNameFromUrl(thumbnailUrl);
-		
+
 		Blob blob = storage.get(bucketName, objectName);
 		if (blob != null) {
 			storage.delete(bucketName, objectName);
@@ -65,7 +67,7 @@ public class GcsService {
 			System.out.println("Blob not found: " + objectName);
 		}
 	}
-	
+
 	// photo 파일 삭제
 	public void deletePhotoToGcs(List<Photo> photos) throws FileNotFoundException, IOException {
 
@@ -96,4 +98,31 @@ public class GcsService {
 		int index = url.indexOf("minography_gcs/") + "minography_gcs/".length();
 		return url.substring(index);
 	}
+
+	public String uploadWebpFile(MultipartFile multipartFile, Long projectId) throws IOException {
+	    InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
+	    String uuid = UUID.randomUUID().toString();
+	    String objectName = projectId + "/" + uuid + ".webp";  // WebP 확장자로 설정
+
+	    // Scrimage를 사용하여 WebP 형식으로 변환 및 압축 품질, 방법, 수준 설정
+	    ImmutableImage image = ImmutableImage.loader().fromStream(multipartFile.getInputStream());
+	    
+	    // 품질을 80, 압축 방법을 4, 데이터 압축 수준을 9로 설정하여 WebpWriter 생성
+	    WebpWriter writer = WebpWriter.DEFAULT.withQ(80).withM(4).withZ(9);
+
+	    byte[] webpBytes = image.bytes(writer); // 설정된 옵션으로 webp 이미지 생성
+
+	    Storage storage = StorageOptions.newBuilder()
+	        .setCredentials(GoogleCredentials.fromStream(keyFile))
+	        .build().getService();
+
+	    BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName)
+	        .setContentType("image/webp")
+	        .build();
+
+	    // GCS에 업로드
+	    storage.create(blobInfo, webpBytes);
+	    return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
+	}
+
 }

--- a/src/main/java/com/example/portfolio/service/PhotoService.java
+++ b/src/main/java/com/example/portfolio/service/PhotoService.java
@@ -33,22 +33,24 @@ public class PhotoService {
 
 	// 사진 생성
 	public void createPhotos(ProjectCreateDto projectCreateDto, Long projectId) {
-		MultipartFile[] multipartFiles = projectCreateDto.getPhotoMultipartFiles();
+	    MultipartFile[] multipartFiles = projectCreateDto.getPhotoMultipartFiles();
 
-		for (MultipartFile multipartFile : multipartFiles) {
-			try {
-				Photo photo = new Photo();
-				String url = gcsService.uploadFile(multipartFile, projectId);
-				photo.setImageUrl(url);
-				photo.setImgoname(multipartFile.getOriginalFilename());
-				photo.setImgtype(multipartFile.getContentType());
-				photo.setProjectId(projectId);
-				photoRepository.save(photo);
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
-		}
+	    for (MultipartFile multipartFile : multipartFiles) {
+	        try {
+	            Photo photo = new Photo();
+	            // WebP 형식으로 변환된 이미지를 GCS에 업로드
+	            String url = gcsService.uploadWebpFile(multipartFile, projectId); // WebP 형식 업로드 메서드 호출
+	            photo.setImageUrl(url);
+	            photo.setImgoname(multipartFile.getOriginalFilename());
+	            photo.setImgtype("image/webp"); // 변환 후 이미지 형식을 webp로 설정
+	            photo.setProjectId(projectId);
+	            photoRepository.save(photo);
+	        } catch (IOException e) {
+	            e.printStackTrace();
+	        }
+	    }
 	}
+
 
 	// 사진 업데이트
 	public void updatePhotos(ProjectUpdateDto projectUpdateDto) {
@@ -58,7 +60,7 @@ public class PhotoService {
 			Photo newPhoto = createPhoto(multipartFile, projectUpdateDto.getId());
 
 				try {
-					String url = gcsService.uploadFile(multipartFile, projectUpdateDto.getId());
+					String url = gcsService.uploadWebpFile(multipartFile, projectUpdateDto.getId());
 					newPhoto.setImageUrl(url);
 					newPhoto.setImgoname(multipartFile.getOriginalFilename());
 					newPhoto.setImgtype(multipartFile.getContentType());

--- a/src/test/java/com/example/portfolio/service/PhotoServiceTest.java
+++ b/src/test/java/com/example/portfolio/service/PhotoServiceTest.java
@@ -81,7 +81,7 @@ class PhotoServiceTest {
 	    
 	    // GcsService mock 설정
 	    // eq는 모키토 라이브러리에서 제공하는 인자 매처로 정확하게 일치하는 값만 인정함
-			when(gcsService.uploadFile(any(MultipartFile.class), eq(projectId)))
+			when(gcsService.uploadWebpFile(any(MultipartFile.class), eq(projectId)))
 			    .thenReturn("http://example.com/photo1.jpg")
 			    .thenReturn("http://example.com/photo2.jpg");
 
@@ -117,7 +117,7 @@ class PhotoServiceTest {
         assertThat(secondPhoto.getProjectId()).isEqualTo(projectId);
         
         // GcsService 호출 확인
-        verify(gcsService, times(2)).uploadFile(any(MultipartFile.class), eq(projectId));
+        verify(gcsService, times(2)).uploadWebpFile(any(MultipartFile.class), eq(projectId));
 	    
 	    
 		} catch (IOException e) {

--- a/src/test/java/com/example/portfolio/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/portfolio/service/ProjectServiceTest.java
@@ -87,8 +87,8 @@ class ProjectServiceTest {
 	    
 		 // When
 		 // 사진 업로드 및 url 리턴 코드
-		when(gcsService.uploadFile(thumbnailFile, projectId)).thenReturn("http:localhost8181/thumbnail.jpg");
-		String url = gcsService.uploadFile(thumbnailFile, projectId);
+		when(gcsService.uploadWebpFile(thumbnailFile, projectId)).thenReturn("http:localhost8181/thumbnail.jpg");
+		String url = gcsService.uploadWebpFile(thumbnailFile, projectId);
 		project.setThumbnailUrl("http:localhost:8181/image.jpg");
 		
 		// Then


### PR DESCRIPTION
- 모든 프로젝트 이미지 업로드 시 webp 포맷으로 변환하여 GCS에 저장하도록 변경
- 압축 품질(Q)을 80으로, 압축 방법(M)을 4로, 압축 수준(Z)을 9로 설정하여 최적화
- 기존 uploadFile 메서드 대신 uploadWebpFile 메서드 사용으로 교체
- webp 포맷 적용으로 파일 크기 감소 및 로딩 속도 개선 기대