### PR TITLE
fix: remove unnecessary try-catch block and handle IOException

### DIFF
--- a/src/test/java/com/example/portfolio/service/PhotoServiceTest.java
+++ b/src/test/java/com/example/portfolio/service/PhotoServiceTest.java
@@ -40,10 +40,7 @@ class PhotoServiceTest {
 	private PhotoRepository photoRepository;
 	
 	@Test
-	void testname() {
-		try {
-		// Given
-		
+	void testname() throws IOException {
 		ProjectCreateDto projectCreateDto = new ProjectCreateDto();
 		projectCreateDto.setTitle("서비스테스트제목");
 		projectCreateDto.setCategoryId(1L);
@@ -118,11 +115,5 @@ class PhotoServiceTest {
         
         // GcsService 호출 확인
         verify(gcsService, times(2)).uploadWebpFile(any(MultipartFile.class), eq(projectId));
-	    
-	    
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
 	}
 }

--- a/src/test/java/com/example/portfolio/service/ProjectServiceTest.java
+++ b/src/test/java/com/example/portfolio/service/ProjectServiceTest.java
@@ -42,9 +42,8 @@ class ProjectServiceTest {
 	
 	@Test
 	@DisplayName("프로젝트서비스 전체 성공 테스트")
-	void ProjectServiceSuccessTest() {
+	void ProjectServiceSuccessTest() throws IOException {
 		
-		try {
 		// Given
 		ProjectCreateDto projectCreateDto = new ProjectCreateDto();
 		projectCreateDto.setTitle("서비스테스트제목");
@@ -100,10 +99,6 @@ class ProjectServiceTest {
 	   
 		assertThat(projectId).isEqualTo(1L);
 		assertThat(url).isEqualTo("http:localhost8181/thumbnail.jpg");
-		
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
 	    
 	}
 


### PR DESCRIPTION
- ProjectServiceSuccessTest 메서드에서 불필요한 try-catch 구문 제거
- 테스트 메서드에 throws IOException을 추가하여 예외 발생 시 테스트 실패하도록 설정
- 코드 가독성 향상 및 테스트 에러 원인 명확화