### PR TITLE
refactor: createProject 메서드 성능 개선

### DIFF
--- a/src/main/java/com/example/portfolio/service/GcsService.java
+++ b/src/main/java/com/example/portfolio/service/GcsService.java
@@ -1,10 +1,12 @@
 package com.example.portfolio.service;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -24,163 +26,93 @@ import com.google.cloud.storage.StorageOptions;
 import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.webp.WebpWriter;
 
-
-//구글 클라우드 스토리지 관련 로직
 @Service
 public class GcsService {
 
-	@Value("${spring.cloud.gcp.storage.project-id}")
-	private String projectId;
+    @Value("${spring.cloud.gcp.storage.bucket}")
+    private String bucketName;
 
-	@Value("${spring.cloud.gcp.storage.credentials.location}")
-	private String keyFileName;
+    private final Storage storage;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(4);
 
-	@Value("${spring.cloud.gcp.storage.bucket}")
-	private String bucketName;
+    public GcsService(@Value("${spring.cloud.gcp.storage.credentials.location}") String keyFileName) throws IOException {
+        InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
+        this.storage = StorageOptions.newBuilder()
+                .setCredentials(GoogleCredentials.fromStream(keyFile))
+                .build()
+                .getService();
+    }
 
-	// GCS 업로드 메소드
-//	public String uploadFile(MultipartFile multipartFile, Long projectId) throws IOException {
-//		// Google Cloud 인증에 사용되는 서비스 계정 키 파일을 스트림 형태로 읽어야 동작
-//		// fromStream() 메소드가 InputStream을 매개변수로 받기 때문에 키 파일을 스트림 형태로 읽어와야함
-//		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-//		String uuid = UUID.randomUUID().toString();
-//		String extension = multipartFile.getContentType();
-//		String objectName = projectId + "/" + uuid + "." + extension.split("/")[1];
-//
-//		Storage storage = StorageOptions.newBuilder().setCredentials(GoogleCredentials.fromStream(keyFile)).build()
-//				.getService();
-//
-//		BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName).setContentType(extension).build();
-//
-//		storage.createFrom(blobInfo, multipartFile.getInputStream());
-//		return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
-//	}
+    // WebP 파일 업로드 메서드
+    public String uploadWebpFile(MultipartFile multipartFile, Long projectId) {
+        try {
+            String uuid = UUID.randomUUID().toString();
+            String objectName = projectId + "/" + uuid + ".webp";
 
-	// 썸네일 파일 삭제
-	public void deleteThumbnailFile(String thumbnailUrl) {
-		try {
-		InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-			Storage storage = StorageOptions.newBuilder()
-					.setCredentials(GoogleCredentials.fromStream(keyFile))
-					.build()
-					.getService();
-			
-			String objectName = getObjectNameFromUrl(thumbnailUrl);
-			Blob blob = storage.get(bucketName, objectName);
-			
-			if (blob != null) {
-				storage.delete(bucketName, objectName);
-			} else {
-				throw new CustomException(
-						HttpStatus.NOT_FOUND, // 404
-		                ErrorCode.STORAGE_FILE_NOT_FOUND,
-		                "Blob not found: " + objectName
-						);
-			}
-			
-		} catch (FileNotFoundException e) {
-			throw new CustomException(
-					HttpStatus.NOT_FOUND,  // 404
-		            ErrorCode.STORAGE_KEY_FILE_NOT_FOUND,
-		            "Failed to find storage key file: " + e.getMessage()
-					);
-			
-		} catch (IOException e) {
-			throw new CustomException(
-		            HttpStatus.INTERNAL_SERVER_ERROR,  // 500
-		            ErrorCode.STORAGE_IO_ERROR,
-		            "Storage operation failed: " + e.getMessage()
-		        );
-		}
-	}
+            // WebP 이미지 변환
+            ImmutableImage image = ImmutableImage.loader().fromStream(multipartFile.getInputStream());
+            WebpWriter writer = WebpWriter.DEFAULT.withQ(80).withM(4).withZ(9);
+            byte[] webpBytes = image.bytes(writer);
 
-	// photo 파일 삭제
-	public void deletePhotoToGcs(List<Photo> photos){
+            BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName)
+                    .setContentType("image/webp")
+                    .build();
 
-		// fromStream() 메소드가 InputStream을 매개변수로 받기 때문에 키 파일을 스트림 형태로 읽어와야함
-		try {
-			InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-			Storage storage = StorageOptions.newBuilder()
-					.setCredentials(GoogleCredentials.fromStream(keyFile))
-					.build()
-					.getService();
-			
-			// 사진들에서 url만 뽑아서 다시 리스트로 만듬
-			List<String> urls = photos.stream()
-					.map(p -> p.getImageUrl())
-					.collect(Collectors.toList());
-			
-			for (String url : urls) {
-				// minography_gcs가 처음 찾아지는 0 과 minography_gcs/의 길이 15를 합쳐서 15 값 저장
-				String objectName = getObjectNameFromUrl(url); // 인덱스로 잘라서 objectName을 만들고
-				Blob blob = storage.get(bucketName, objectName); // 사진이 있는지 확인
-				
-				if (blob != null) {
-					storage.delete(bucketName, objectName); // gcs에서 삭제하는 로직
-				} else {
-					throw new CustomException(
-		                    HttpStatus.NOT_FOUND,
-		                    ErrorCode.STORAGE_FILE_NOT_FOUND,
-		                    "File not found in storage: " + objectName
-		                );
-				}
-			}
-			
-		} catch (FileNotFoundException e) {
-			throw new CustomException(
-		            HttpStatus.NOT_FOUND,
-		            ErrorCode.STORAGE_KEY_FILE_NOT_FOUND,
-		            "Storage key file not found: " + e.getMessage()
-		        );
-		} catch (IOException e) {
-			throw new CustomException(
-		            HttpStatus.INTERNAL_SERVER_ERROR,
-		            ErrorCode.STORAGE_IO_ERROR,
-		            "Storage operation failed: " + e.getMessage()
-		        );
-		}
-	}
+            // GCS에 비동기 업로드
+            CompletableFuture.runAsync(() -> storage.create(blobInfo, webpBytes), executorService);
 
-	// url로 object 이름 가져오는 메소드
-	public String getObjectNameFromUrl(String url) {
-		int index = url.indexOf("minography_gcs/") + "minography_gcs/".length();
-		return url.substring(index);
-	}
+            return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
 
-	public String uploadWebpFile(MultipartFile multipartFile, Long projectId) {
-		try {
-			InputStream keyFile = ResourceUtils.getURL(keyFileName).openStream();
-			String uuid = UUID.randomUUID().toString();
-			String objectName = projectId + "/" + uuid + ".webp";  // WebP 확장자로 설정
-			
-			// Scrimage를 사용하여 WebP 형식으로 변환 및 압축 품질, 방법, 수준 설정
-			ImmutableImage image = ImmutableImage.loader().fromStream(multipartFile.getInputStream());
-			
-			// 품질을 80, 압축 방법을 4, 데이터 압축 수준을 9로 설정하여 WebpWriter 생성
-			WebpWriter writer = WebpWriter.DEFAULT.withQ(80).withM(4).withZ(9);
-			
-			byte[] webpBytes = image.bytes(writer); // 설정된 옵션으로 webp 이미지 생성
-			
-			Storage storage = StorageOptions.newBuilder()
-					.setCredentials(GoogleCredentials.fromStream(keyFile))
-					.build()
-					.getService();
-			
-			BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, objectName)
-					.setContentType("image/webp")
-					.build();
-			
-			// GCS에 업로드
-			storage.create(blobInfo, webpBytes);
-			return "https://storage.googleapis.com/" + bucketName + "/" + objectName;
-			
-		}  catch (IOException e) {
-			throw new CustomException(
-		            HttpStatus.INTERNAL_SERVER_ERROR,
-		            ErrorCode.STORAGE_IO_ERROR,
-		            "Failed to upload file: " + e.getMessage()
-		    );
-		}
-	}
- 
+        } catch (IOException e) {
+            throw new CustomException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    ErrorCode.STORAGE_IO_ERROR,
+                    "Failed to upload file: " + e.getMessage()
+            );
+        }
+    }
+
+    // 썸네일 파일 삭제
+    public void deleteThumbnailFile(String thumbnailUrl) {
+        String objectName = getObjectNameFromUrl(thumbnailUrl);
+        Blob blob = storage.get(bucketName, objectName);
+
+        if (blob != null) {
+            storage.delete(bucketName, objectName);
+        } else {
+            throw new CustomException(
+                    HttpStatus.NOT_FOUND,
+                    ErrorCode.STORAGE_FILE_NOT_FOUND,
+                    "Blob not found: " + objectName
+            );
+        }
+    }
+
+    // photo 파일 삭제
+    public void deletePhotoToGcs(List<Photo> photos) {
+        List<String> urls = photos.stream()
+                .map(Photo::getImageUrl)
+                .collect(Collectors.toList());
+
+        for (String url : urls) {
+            String objectName = getObjectNameFromUrl(url);
+            Blob blob = storage.get(bucketName, objectName);
+
+            if (blob != null) {
+                storage.delete(bucketName, objectName);
+            } else {
+                throw new CustomException(
+                        HttpStatus.NOT_FOUND,
+                        ErrorCode.STORAGE_FILE_NOT_FOUND,
+                        "File not found in storage: " + objectName
+                );
+            }
+        }
+    }
+
+    // url로 object 이름 가져오는 메서드
+    public String getObjectNameFromUrl(String url) {
+        int index = url.indexOf("minography_gcs/") + "minography_gcs/".length();
+        return url.substring(index);
+    }
 }

--- a/src/main/java/com/example/portfolio/service/PhotoService.java
+++ b/src/main/java/com/example/portfolio/service/PhotoService.java
@@ -1,14 +1,17 @@
 package com.example.portfolio.service;
 
-import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.portfolio.dto.ProjectCreateDto;
 import com.example.portfolio.dto.ProjectUpdateDto;
-import com.example.portfolio.exception.CustomException;
 import com.example.portfolio.model.Photo;
 import com.example.portfolio.repository.PhotoRepository;
 import com.example.portfolio.repository.ProjectRepository;
@@ -19,6 +22,7 @@ public class PhotoService {
 	private final GcsService gcsService;
 	private final PhotoRepository photoRepository;
 	private final ProjectRepository projectRepository;
+	private final ExecutorService executorService = Executors.newFixedThreadPool(4); // 스레드 풀을 필드에 선언하여 재사용
 
 	//생성자 주입
 	public PhotoService(GcsService gcsService, PhotoRepository photoRepository, ProjectRepository projectRepository) {
@@ -27,22 +31,31 @@ public class PhotoService {
 		this.projectRepository = projectRepository;
 	}
 
-	// 사진 생성
-	public void createPhotos(ProjectCreateDto projectCreateDto, Long projectId) {
-	    MultipartFile[] multipartFiles = projectCreateDto.getPhotoMultipartFiles();
 
-	    for (MultipartFile multipartFile : multipartFiles) {
-	            Photo photo = new Photo();
-	            // WebP 형식으로 변환된 이미지를 GCS에 업로드
-	            // uploadWebpFile 안에서 try catch로 예외 잡고 있어서 여기서는 예외 처리 불필요
-	            String url = gcsService.uploadWebpFile(multipartFile, projectId); // WebP 형식 업로드 메서드 호출
-	            photo.setImageUrl(url);
-	            photo.setImgoname(multipartFile.getOriginalFilename());
-	            photo.setImgtype("image/webp"); // 변환 후 이미지 형식을 webp로 설정
-	            photo.setProjectId(projectId);
-	            photoRepository.save(photo);
-	    }
-	}
+    public void createPhotos(ProjectCreateDto projectCreateDto, Long projectId) {
+        MultipartFile[] multipartFiles = projectCreateDto.getPhotoMultipartFiles();
+        List<CompletableFuture<Photo>> futures = new ArrayList<>();
+
+        for (MultipartFile multipartFile : multipartFiles) {
+            // CompletableFuture를 사용하여 비동기 처리
+            CompletableFuture<Photo> future = CompletableFuture.supplyAsync(() -> {
+                Photo photo = new Photo();
+                String url = gcsService.uploadWebpFile(multipartFile, projectId);
+                photo.setImageUrl(url);
+                photo.setImgoname(multipartFile.getOriginalFilename());
+                photo.setImgtype("image/webp"); 
+                photo.setProjectId(projectId);
+                return photo;
+            }, executorService);
+
+            futures.add(future);
+        }
+
+        List<Photo> photos = futures.stream().map(CompletableFuture::join).collect(Collectors.toList());
+
+        // 한번에 저장
+        photoRepository.saveAll(photos);
+    }
 
 	// 사진 업데이트
 	public void updatePhotos(ProjectUpdateDto projectUpdateDto) {

--- a/src/main/java/com/example/portfolio/service/ProjectService.java
+++ b/src/main/java/com/example/portfolio/service/ProjectService.java
@@ -2,6 +2,8 @@ package com.example.portfolio.service;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -25,7 +27,7 @@ import jakarta.transaction.Transactional;
 
 @Service
 public class ProjectService {
-
+	
 	private final ProjectRepository projectRepository;
 	private final GcsService gcsService;
 	private final PhotoService photoService;
@@ -43,24 +45,21 @@ public class ProjectService {
 		this.photoRepository = photoRepository;
 	}
 
-	// 프로젝트 생성
 	@Transactional
 	public void createProject(ProjectCreateDto projectCreateDtos) {
 	    Project project = projectMapper.createDtoToProject(projectCreateDtos);
+
 	    Long projectId = projectRepository.save(project).getId();
 
-	    // 썸네일 생성 및 변환
 	    MultipartFile multipartFile = projectCreateDtos.getThumbnailMultipartFile();
-        // WebP로 변환한 이미지를 GCS에 업로드
-        String url = gcsService.uploadWebpFile(multipartFile, projectId);
-        project.setThumbnailUrl(url);
-	
-	    // 사진 생성
+	    String url = gcsService.uploadWebpFile(multipartFile, projectId);
+	    project.setThumbnailUrl(url);
+
 	    photoService.createPhotos(projectCreateDtos, projectId);
 
-	    // 최종적으로 프로젝트 업데이트
 	    projectRepository.save(project);
 	}
+
 
 	// 프로젝트 업데이트
 	@Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,7 +31,7 @@ spring.servlet.multipart.max-request-size=10MB
 #spring.jpa.properties.hibernate.jdbc.use_get_generated_keys=false
 
 spring.datasource.hikari.maximum-pool-size=10
-spring.jpa.properties.hibernate.default_batch_fetch_size=10
+spring.jpa.properties.hibernate.default_batch_fetch_size=30
 spring.datasource.hikari.data-source-properties.cachePrepStmts=true
 spring.datasource.hikari.data-source-properties.prepStmtCacheSize=250
 spring.datasource.hikari.data-source-properties.prepStmtCacheSqlLimit=2048


### PR DESCRIPTION
- GCS Storage 객체 싱글톤화로 인증 객체 재사용성 확보 및 성능 최적화
- photoService와 gcsService에서 비동기 작업을 위해 ExecutorService 기반의 스레드 풀 도입
- CompletableFuture를 사용한 비동기 업로드 처리로 응답 시간 단축
- batch insert 방식 적용을 통해 데이터베이스와의 통신 횟수 감소
- 필요 없는 예외 제거 및 CustomException으로 예외 처리 일관성 강화